### PR TITLE
Fix typing cursor duplication when switching lines

### DIFF
--- a/api/animations/typing.js
+++ b/api/animations/typing.js
@@ -34,14 +34,13 @@ module.exports = (ctx) => {
             </rect>
         </clipPath>`;
 
-        const cursorValues = `${tx};${tx};${tx + totalLineWidth};${tx + totalLineWidth};${tx};${tx}`;
+        const cursorValues = `${tx};${tx};${tx + totalLineWidth};${tx + totalLineWidth};${tx + totalLineWidth};${tx + totalLineWidth}`;
 
         body += `<text x="${textX}" y="${lineY(i)}" text-anchor="${textAnchor}" style="${commonStyle}" clip-path="url(#${clipId})" opacity="0">
             ${sequenceOpacity(i)}
             ${line}
         </text>
         <rect x="${tx}" y="${lineY(i) - intSize + 4}" width="2" height="${intSize}" fill="${textColor}" opacity="0">
-            ${sequenceOpacity(i)}
             <animate attributeName="x"
                 values="${cursorValues}"
                 keyTimes="0;${clamp01(t0)};${clamp01(t1)};${clamp01(t2)};${clamp01(t3)};1"
@@ -49,7 +48,7 @@ module.exports = (ctx) => {
                 repeatCount="${repeat ? 'indefinite' : '1'}"
                 fill="freeze" />
             <animate attributeName="opacity"
-                values="0;0;1;1;1;0"
+                values="0;0;1;1;0;0"
                 keyTimes="0;${clamp01(t0)};${clamp01(t1)};${clamp01(t2)};${clamp01(t3)};1"
                 dur="${cycleDurS}s"
                 repeatCount="${repeat ? 'indefinite' : '1'}"


### PR DESCRIPTION
### Motivation
- Prevent a stale blinking cursor from remaining at the left side when the typing animation transitions between multiple lines. 

### Description
- Adjusted the cursor X animation timeline in `api/animations/typing.js` so the cursor stays at the right edge during erase phase instead of moving back left. 
- Removed the `sequenceOpacity` animation from the cursor rectangle and unified the cursor opacity keyframes to hide the cursor before the erase completes. 
- The change targets multi-line `typing` animation cursor behavior and only touches `api/animations/typing.js`.

### Testing
- Ran a Node smoke check with `node -e "const getAnimation=require('./api/animations'); ... console.log(out.includes('values=\"20;20;')?'ok':'check');"` and it returned `ok`.
- Executed an automated Playwright script to render the updated SVG and capture a screenshot, and the script completed successfully (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc4696a58832fbc58d601b6f7a30e)