### PR TITLE
Add .gitignore for Node.js and Vercel artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules/
+
+# Vercel
+.vercel/
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Build and coverage artifacts
+dist/
+build/
+coverage/
+
+# OS and editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/
+*.swp


### PR DESCRIPTION
### Motivation
- Prevent common local, build, and environment files (dependencies, Vercel state, env files, logs, build/coverage artifacts, and editor/OS temp files) from being committed to the repository.

### Description
- Add a root `.gitignore` containing entries for `node_modules/`, `.vercel/`, `env` files (`.env`, `.env.*`, and `!.env.example`), log patterns, `dist/`/`build/`/`coverage/`, and common OS/editor files like `.DS_Store`, `.vscode/`, `.idea/`, and `*.swp`.

### Testing
- Inspected the created file with `nl -ba .gitignore` and checked repository status with `git status --short`, confirming the `.gitignore` contents and expected repository state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80bdc20988331a11e1f7b84858a87)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated repository configuration with comprehensive ignore patterns covering dependencies, deployment files, environment variables, build artifacts, coverage reports, application logs, and development tool directories to improve version control management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->