### PR TITLE
Add Vercel static build entry for assets directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
       "use": "@vercel/node"
     },
     {
+      "src": "assets/(.*)",
+      "use": "@vercel/static"
+    },
+    {
       "src": "index.html",
       "use": "@vercel/static"
     }


### PR DESCRIPTION
### Motivation
- Ensure CSS/JS under `assets/` are included in Vercel builds so the page doesn't render as unstyled HTML in preview/prod.

### Description
- Added a `builds` entry in `vercel.json` for `assets/(.*)` using `@vercel/static` so static files are built and served from the `assets/` folder, leaving existing API and `index.html` builds and routes unchanged.

### Testing
- Validated `vercel.json` syntax with `python -m json.tool vercel.json` which returned `OK`.
- Attempted a Playwright-based runtime check against the preview URL, but the request returned a `401` (login required), so live verification of the preview was blocked and remains inconclusive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedfcd94a4832f9cfc8b2f9ea9aa17)