### PR TITLE
style: tighten dark Material theme with strict dark background

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -4,15 +4,16 @@
    MATERIAL DESIGN 3 — DARK THEME TOKENS
    ═══════════════════════════════════════ */
 :root {
+  color-scheme: dark;
   /* MD3 Dark Surface Hierarchy */
-  --md-sys-color-background:        #0f0f13;
-  --md-sys-color-surface:           #1c1b1f;
+  --md-sys-color-background:        #0a0a0d;
+  --md-sys-color-surface:           #151419;
   --md-sys-color-surface-variant:   #49454f;
-  --md-sys-color-surface-container-lowest:  #0f0e11;
-  --md-sys-color-surface-container-low:     #1d1b20;
-  --md-sys-color-surface-container:         #211f26;
-  --md-sys-color-surface-container-high:    #2b2930;
-  --md-sys-color-surface-container-highest: #36343b;
+  --md-sys-color-surface-container-lowest:  #0b0b10;
+  --md-sys-color-surface-container-low:     #14131a;
+  --md-sys-color-surface-container:         #1b1a22;
+  --md-sys-color-surface-container-high:    #24232b;
+  --md-sys-color-surface-container-highest: #2e2d36;
 
   /* MD3 Primary — Purple */
   --md-sys-color-primary:           #d0bcff;
@@ -76,7 +77,8 @@
 
 body {
   font-family: var(--md-font-body);
-  background: var(--md-sys-color-background);
+  background-color: var(--md-sys-color-background);
+  background-image: none;
   color: var(--md-sys-color-on-surface);
   min-height: 100vh;
   padding: 0 0 80px;
@@ -183,13 +185,7 @@ header nav {
 }
 
 .hero::before {
-  content: '';
-  position: absolute;
-  inset: -100px;
-  background:
-    radial-gradient(ellipse 60% 40% at 50% 0%, rgba(79,55,139,0.35) 0%, transparent 70%),
-    radial-gradient(ellipse 40% 30% at 80% 60%, rgba(3,218,198,0.08) 0%, transparent 60%);
-  pointer-events: none;
+  content: none;
 }
 
 .hero h1 {


### PR DESCRIPTION
### Motivation
- Make the site follow a stricter dark Google Material look by deepening background and surface tokens and removing decorative light accents so the page is consistently dark.

### Description
- Updated Material dark tokens in `:root` inside `assets/css/styles.css` to deeper `background` and `surface` values and adjusted surface-container shades.
- Added `color-scheme: dark;`, enforced `background-color: var(--md-sys-color-background)` and disabled `background-image` on `body` to ensure a strict dark page background.
- Removed the hero glow overlay by replacing the `.hero::before` radial gradients with `content: none;` to avoid stray highlights.

### Testing
- Launched a local server with `python3 -m http.server 4173` and verified the site served successfully.
- Reviewed the CSS diff with `git diff -- assets/css/styles.css` to confirm token and rule updates.
- Captured a Playwright screenshot of the running app to validate the visual result; the screenshot was successfully created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee46b16888331845ff407aea8de8d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Established dark color scheme as the primary application theme
  * Enhanced dark theme colors with deeper values for background and surface containers, improving visual contrast and interface hierarchy
  * Simplified hero section by removing decorative gradient overlay effects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->